### PR TITLE
Typos and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,15 @@ class MyApp extends StatelessWidget {
         backgroundColor: Colors.black,
         body: ParticleNetwork(
           particleCount: 60,          // Number of particles
-          maxSpeed: 0.7,              // Maximum velocity
-          maxSize: 3.5,               // Particle size
-          lineDistance: 180,          // Connection distance
+          maxSpeed: 0.5,              // Maximum velocity
+          maxSize: 1.5,               // Particle size
+          lineWidth: 0.5,             // Connection line thickness
+          lineDistance: 100,          // Connection distance
           particleColor: Colors.white,
-          lineColor: const Color(0xFF4CFFA7),
-          touchColor: Colors.amber,    // Color on touch
+          lineColor: const Color.fromARGB(255, 100, 255, 180),
+          touchColor: Colors.amber,   // Color on touch
           touchActivation: true,      // Enable touch
-          drawnetwork: true,          // Show connections
+          drawNetwork: true,          // Show connections
           fill: false,                // Outline particles
           isComplex: false,           // Optimize performance
         ),
@@ -104,22 +105,24 @@ class MyApp extends StatelessWidget {
 }
 ```
 
+See the complete tutorial [here](https://youtu.be/FZyFgUXCrHg).
+
 ## ⚙️ Configuration
 
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `particleCount` | `int` | `50` | Number of particles in the system |
-| `maxSpeed` | `double` | `0.5` | Maximum particle velocity |
-| `maxSize` | `double` | `3.5` | Maximum particle radius |
-| `lineDistance` | `double` | `100` | Maximum connection distance |
-| `particleColor` | `Color` | `Colors.white` | Particle color |
-| `lineColor` | `Color` | `Colors.teal` | Connection line color |
-| `touchColor` | `Color` | `Colors.amber` | Touch highlight color |
-| `touchActivation` | `bool` | `false` | Enable touch interaction |
-| `drawnetwork` | `bool` | `true` | Show particle connections |
-| `fill` | `bool` | `true` | Fill vs outline particles |
-| `isComplex` | `bool` | `false` | Optimize complex scenes |
-| `linewidth` | `double` | `0.5` | Connection line thickness |
+| Property          | Type     | Default        | Description                       |
+|-------------------|----------|----------------|-----------------------------------|
+| `particleCount`   | `int`    | `60`           | Number of particles in the system |
+| `maxSpeed`        | `double` | `0.5`          | Maximum particle velocity         |
+| `maxSize`         | `double` | `1.5`          | Maximum particle radius           |
+| `lineWidth`       | `double` | `0.5`          | Connection line thickness         |
+| `lineDistance`    | `double` | `100`          | Maximum connection distance       |
+| `particleColor`   | `Color`  | `Colors.white` | Particle color                    |
+| `lineColor`       | `Color`  | `Colors.teal`  | Connection line color             |
+| `touchColor`      | `Color`  | `Colors.amber` | Touch highlight color             |
+| `touchActivation` | `bool`   | `true`         | Enable touch interaction          |
+| `isComplex`       | `bool`   | `false`        | Optimize complex scenes           |
+| `fill`            | `bool`   | `true`         | Fill vs outline particles         |
+| `drawNetwork`     | `bool`   | `true`         | Show particle connections         |
 
 ## 🎯 Advanced Usage
 
@@ -156,6 +159,10 @@ Stack(
 - Reduce `particleCount` and `lineDistance` for better performance on low-end devices
 - Set `isComplex: true` for scenes with many particles
 - Use `fill: false` for a lighter visual style that's also more performant
+
+### Articles and videos
+
+- [Particles Network Package || All Properties Explained + Custom Examples || Flutter Tutorial](https://youtu.be/FZyFgUXCrHg)
 
 ## 🔧 Under the Hood
 

--- a/lib/painter/optimized_network_painter.dart
+++ b/lib/painter/optimized_network_painter.dart
@@ -33,11 +33,11 @@ class OptimizedNetworkPainter extends CustomPainter {
   final Color touchColor; // Color for touch interactions
   final bool touchActivation; // Whether touch effects are enabled
   final int particleCount; // Total particle count (for pre-allocation)
-  final double linewidth; // Width of connection lines
+  final double lineWidth; // Width of connection lines
   final bool isComplex; // Debug mode flag
   // final BuildContext context; // Build context for media queries
   final bool fill; // Whether to fill particles or stroke them
-  final bool drawnetwork; // Whether to draw connection lines
+  final bool drawNetwork; // Whether to draw connection lines
   final bool showQuadTree; // Whether to visualize QuadTree structure
 
   // Optimized sub-components
@@ -59,11 +59,11 @@ class OptimizedNetworkPainter extends CustomPainter {
     required this.lineColor,
     required this.touchColor,
     required this.touchActivation,
-    required this.linewidth,
+    required this.lineWidth,
     required this.isComplex,
     // required this.context,
     required this.fill,
-    required this.drawnetwork,
+    required this.drawNetwork,
     this.showQuadTree = false, // Default to false
   }) {
     // Get viewport dimensions for QuadTree initialization
@@ -84,7 +84,7 @@ class OptimizedNetworkPainter extends CustomPainter {
     // Initialize line paint with stroke configuration
     linePaint = Paint()
       ..style = fill ? PaintingStyle.stroke : PaintingStyle.fill
-      ..strokeWidth = linewidth
+      ..strokeWidth = lineWidth
       ..color = lineColor; // Added line color
 
     // Initialize sub-components with dependency injection
@@ -107,7 +107,7 @@ class OptimizedNetworkPainter extends CustomPainter {
     );
 
     _quadTree.clear();
-    if (drawnetwork) {
+    if (drawNetwork) {
       for (int i = 0; i < visibleParticles.length; i++) {
         final particle = particles[visibleParticles[i]];
         _quadTree.insert(
@@ -120,7 +120,7 @@ class OptimizedNetworkPainter extends CustomPainter {
       }
     }
 
-    if (drawnetwork) {
+    if (drawNetwork) {
       _drawConnections(canvas, visibleParticles);
     }
 

--- a/lib/particles_network.dart
+++ b/lib/particles_network.dart
@@ -34,7 +34,7 @@ import 'model/default_particle_factory.dart';
 class ParticleNetwork extends StatefulWidget {
   // Configuration properties with default values:
 
-  /// Total number of particles in the visualization [default: 50]
+  /// Total number of particles in the visualization [default: 60]
   /// Affects performance: O(n) for updates, O(n²) for connection checks
   final int particleCount;
 
@@ -42,18 +42,21 @@ class ParticleNetwork extends StatefulWidget {
   /// Determines how fast particles move (velocity magnitude)
   final double maxSpeed;
 
-  /// Maximum radius of particles in pixels [default: 3.5]
+  /// Maximum radius of particles in pixels [default: 1.5]
   /// Used for rendering particle size
   final double maxSize;
+  
+  /// Stroke width of connection lines in pixels [default: 0.5]
+  final double lineWidth;
 
-  /// Maximum connection distance between particles in pixels [default: 180]
+  /// Maximum connection distance between particles in pixels [default: 100]
   /// Threshold for drawing connecting lines (Euclidean distance)
   final double lineDistance;
 
   /// Base color of all particles [default: Colors.white]
   final Color particleColor;
 
-  /// Color of connection lines between particles [default: Color(0xFF64FFB4)]
+  /// Color of connection lines between particles [default: Color.fromARGB(255, 100, 255, 180)]
   /// Lines are drawn with opacity based on distance (inverse linear interpolation)
   final Color lineColor;
 
@@ -65,9 +68,6 @@ class ParticleNetwork extends StatefulWidget {
   /// Adds gesture detection and touch response logic
   final bool touchActivation;
 
-  /// Stroke width of connection lines in pixels [default: 0.5]
-  final double linewidth;
-
   /// Whether the painting logic is complex (affects repaint strategy) [default: false]
   /// If true, Flutter may optimize repainting differently
   final bool isComplex;
@@ -76,23 +76,23 @@ class ParticleNetwork extends StatefulWidget {
   final bool fill;
 
   /// Whether to draw connecting lines between particles [default: true]
-  final bool drawnetwork;
+  final bool drawNetwork;
 
   /// Creates a ParticleNetwork widget with customizable parameters
   const ParticleNetwork({
     super.key,
     this.particleCount = 60,
-    this.touchActivation = true,
     this.maxSpeed = 0.5,
     this.maxSize = 1.5,
+    this.lineWidth = 0.5,
     this.lineDistance = 100,
     this.particleColor = Colors.white,
     this.lineColor = const Color.fromARGB(255, 100, 255, 180),
     this.touchColor = Colors.amber,
-    this.linewidth = 0.5,
+    this.touchActivation = true,
     this.isComplex = false,
     this.fill = true,
-    this.drawnetwork = true,
+    this.drawNetwork = true,
   });
 
   @override
@@ -197,10 +197,10 @@ class ParticleNetworkState extends State<ParticleNetwork>
             builder: (context, __, ___) => CustomPaint(
               painter: OptimizedNetworkPainter(
                 // Configuration passed to the painter:
-                drawnetwork: widget.drawnetwork, // Whether to draw connections
+                drawNetwork: widget.drawNetwork, // Whether to draw connections
                 fill: widget.fill, // Fill vs stroke particles
                 isComplex: widget.isComplex, // Painting complexity hint
-                linewidth: widget.linewidth, // Connection line thickness
+                lineWidth: widget.lineWidth, // Connection line thickness
                 particleCount: widget.particleCount,
                 touchActivation: widget.touchActivation, // Touch interaction
                 particles: particles, // The particle data

--- a/test/optimizednetworkpainter_test.dart
+++ b/test/optimizednetworkpainter_test.dart
@@ -56,7 +56,7 @@ void main() {
 
     defaultPainter = OptimizedNetworkPainter(
       // context: testContext,
-      drawnetwork: true,
+      drawNetwork: true,
       fill: true,
       isComplex: false,
       particleCount: 1,
@@ -67,7 +67,7 @@ void main() {
       lineColor: Colors.grey,
       touchColor: Colors.red,
       touchActivation: true,
-      linewidth: 1.0,
+      lineWidth: 1.0,
     );
   }
 
@@ -81,9 +81,9 @@ void main() {
       expect(defaultPainter.lineColor, equals(Colors.grey));
       expect(defaultPainter.touchColor, equals(Colors.red));
       expect(defaultPainter.touchActivation, isTrue);
-      expect(defaultPainter.linewidth, equals(1.0));
+      expect(defaultPainter.lineWidth, equals(1.0));
       expect(defaultPainter.fill, isTrue);
-      expect(defaultPainter.drawnetwork, isTrue);
+      expect(defaultPainter.drawNetwork, isTrue);
       expect(defaultPainter.showQuadTree, isFalse);
     });
 
@@ -108,7 +108,7 @@ void main() {
 
       final strokePainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: false,
         isComplex: false,
         particleCount: 1,
@@ -119,7 +119,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       expect(strokePainter.fill, isFalse);
@@ -135,7 +135,7 @@ void main() {
 
       final painter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 2,
@@ -146,7 +146,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       painter.paint(mockCanvas, testScreenSize);
@@ -174,7 +174,7 @@ void main() {
 
         final painter = OptimizedNetworkPainter(
           // context: testContext,
-          drawnetwork: true,
+          drawNetwork: true,
           fill: true,
           isComplex: false,
           particleCount: 7, // Center + 6 surrounding
@@ -185,7 +185,7 @@ void main() {
           lineColor: Colors.grey,
           touchColor: Colors.red,
           touchActivation: true,
-          linewidth: 1.0,
+          lineWidth: 1.0,
         );
 
         painter.paint(mockCanvas, testScreenSize);
@@ -228,7 +228,7 @@ void main() {
 
         final painter = OptimizedNetworkPainter(
           // context: testContext,
-          drawnetwork: true,
+          drawNetwork: true,
           fill: true,
           isComplex: false,
           particleCount: 11, // Central + 10 surrounding
@@ -239,7 +239,7 @@ void main() {
           lineColor: Colors.grey,
           touchColor: Colors.red,
           touchActivation: true,
-          linewidth: 1.0,
+          lineWidth: 1.0,
         );
 
         painter.paint(mockCanvas, testScreenSize);
@@ -262,7 +262,7 @@ void main() {
 
       final touchPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -273,7 +273,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       touchPainter.paint(mockCanvas, testScreenSize);
@@ -285,7 +285,7 @@ void main() {
 
       final noTouchPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -296,7 +296,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: false,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       noTouchPainter.paint(mockCanvas, testScreenSize);
@@ -310,7 +310,7 @@ void main() {
 
       final newPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -321,7 +321,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       expect(newPainter.shouldRepaint(defaultPainter), isTrue);
@@ -332,7 +332,7 @@ void main() {
 
       final newPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -343,7 +343,7 @@ void main() {
         lineColor: Colors.green,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       expect(newPainter.shouldRepaint(defaultPainter), isTrue);
@@ -356,7 +356,7 @@ void main() {
 
       final newPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -367,7 +367,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       expect(newPainter.shouldRepaint(defaultPainter), isTrue);
@@ -380,7 +380,7 @@ void main() {
 
       final newPainter = OptimizedNetworkPainter(
         // context: testContext,
-        drawnetwork: true,
+        drawNetwork: true,
         fill: true,
         isComplex: false,
         particleCount: 1,
@@ -391,7 +391,7 @@ void main() {
         lineColor: Colors.grey,
         touchColor: Colors.red,
         touchActivation: true,
-        linewidth: 1.0,
+        lineWidth: 1.0,
       );
 
       expect(newPainter.shouldRepaint(defaultPainter), isFalse);

--- a/test/particles_network_test.dart
+++ b/test/particles_network_test.dart
@@ -157,7 +157,7 @@ void main() {
               lineColor: customColor,
               touchColor: customColor,
               touchActivation: false,
-              linewidth: 1.0,
+              lineWidth: 1.0,
             ),
           ),
         ),
@@ -175,7 +175,7 @@ void main() {
       expect(particleNetwork.lineColor, equals(customColor));
       expect(particleNetwork.touchColor, equals(customColor));
       expect(particleNetwork.touchActivation, isFalse);
-      expect(particleNetwork.linewidth, equals(1.0));
+      expect(particleNetwork.lineWidth, equals(1.0));
     });
 
     testWidgets('ParticleNetwork handles touch events', (


### PR DESCRIPTION
Updated variable names + typos
- fix: linewidth -> lineWidth
- fix: drawnetwork -> drawNetwork
- fix: typos in doc comment (Values as in the constructor)
- fix: Sorted for better readability: numbers → colors → booleans

Update README + tutorial
- added: complete tutorial on YouTube.
- fix: typos in doc comment (Values and var names as in the constructor)
- fix: Sorted the configuration table to match the constructor order